### PR TITLE
Fix 'peer-channel-state' command, cleanup 'peer_test2' cmd

### DIFF
--- a/lightningd/peer_control.c
+++ b/lightningd/peer_control.c
@@ -2795,136 +2795,8 @@ AUTODATA(json_command, &sendcustommsg_command);
 
 #endif /* DEVELOPER */
 
+
 static struct command_result *json_peer_channel_state(struct command *cmd,
-					       const char *buffer,
-					       const jsmntok_t *obj UNNEEDED,
-					       const jsmntok_t *params)
-{
-// static void json_peer_channel_state(struct command *cmd, const char *buffer,
-// 				    const jsmntok_t *params)
-// {
-	struct json_stream *response;
-	// struct json_result *response = new_json_result(cmd);
-	const jsmntok_t *idtok;
-	char buf[100];
-	// struct db_stmt *stmt,*stmt1;;
-	sqlite3_stmt *stmt,*stmt1;
-	// sqlite3_stmt *stmt;
-	int channel_state=-1,peer_exits;
-	int err, err1;
-	// int err;
-	
-	if (!param(cmd, buffer, params,
-		p_req("id", param_tok, &idtok),
-		// p_opt("id", param_tok, &idtok),
-		NULL))
-	return command_param_failed();
-
-	response = json_stream_success(cmd);
-
-	// if (!json_get_params(cmd, buffer, params,
-	// 		     "id", &idtok,
-	// 		     NULL)) {
-	// 	return;
-	// }
-
-	memcpy(buf,buffer + idtok->start,idtok->end - idtok->start);
-	buf[idtok->end - idtok->start]='\0';
-	printf("-----------\n");
-	printf("buf %s\n", buf);
-	printf("channel_state %d\n", channel_state);
-	printf("-----------\n");
-	/*stmt = db_prepare(cmd->ld->wallet->db,
-						  "SELECT COALESCE(sum(state),0)"
-						  " FROM channels"
-						  " Where id IN "
-						  " (SELECT COALESCE(sum(id),0)"
-						  "  FROM peers"
-						  "  WHERE lower(hex(node_id))=?);");*/
-	err = sqlite3_prepare_v2((sqlite3 *)cmd->ld->wallet->db, "SELECT count(*) FROM peers WHERE lower(hex(node_id))=?;",-1, &stmt, NULL);
-	// err = sqlite3_prepare_v2((sqlite3 *)cmd->ld->wallet->db, "SELECT count(*) FROM peers;",-1, &stmt, NULL);
-	sqlite3_bind_text(stmt, 0, buf, strlen(buf), SQLITE_TRANSIENT);
-	// db_bind_text(stmt, 1, buf);
-
-	if (err != SQLITE_OK) {
-		return false;
-	}
-	
-	while (sqlite3_step(stmt) == SQLITE_ROW) {
-		int i;
-		int num_cols = sqlite3_column_count(stmt);
-		
-		for (i = 0; i < num_cols; i++)
-		{
-			switch (sqlite3_column_type(stmt, i))
-			{
-			case (SQLITE_INTEGER):
-				peer_exits=sqlite3_column_int(stmt, i);
-				break;
-			default:
-				break;
-			}
-		}
-	}
-	sqlite3_finalize(stmt);
-	// json_object_start(response, NULL);
-	json_array_start(response,"channel-states");
-	if(peer_exits == 0)
-	{
-		json_object_start(response,NULL);
-		json_add_num(response, "channel-state", 0);
-		json_object_end(response);
-	}
-	else
-	{	
-			err1 = sqlite3_prepare_v2((sqlite3 *)cmd->ld->wallet->db, "SELECT state FROM channels WHERE peer_id IN (SELECT id FROM peers WHERE lower(hex(node_id))=?);",-1, &stmt1, NULL);
-			sqlite3_bind_text(stmt1, 0, buf, strlen(buf), SQLITE_TRANSIENT);
-			// db_bind_text(stmt1, 1, buf);
-
-			if (err1 != SQLITE_OK) {
-				return false;
-			}
-			
-			while (sqlite3_step(stmt1) == SQLITE_ROW) {
-				int i;
-				int num_cols = sqlite3_column_count(stmt1);
-				
-				for (i = 0; i < num_cols; i++)
-				{
-					switch (sqlite3_column_type(stmt1, i))
-					{
-					case (SQLITE_INTEGER):
-						json_object_start(response,NULL);
-						channel_state=sqlite3_column_int(stmt1, i);
-						json_add_num(response, "channel-state", channel_state);
-						json_object_end(response);
-						break;
-					default:
-						break;
-					}
-				}
-			}
-			sqlite3_finalize(stmt1);
-		
-	}
-	printf("peer_exits: %d\n", peer_exits);
-	json_array_end(response);
-	// json_object_end(response);
-	// command_success(cmd, response);
-	return command_success(cmd, response);
-}
-
-static const struct json_command peer_channel_state = {
-	"peer-channel-state",
-	"developer",
-	json_peer_channel_state,
-	"Find the state of the channel with the peer {id}"
-};
-AUTODATA(json_command, &peer_channel_state);
-
-
-
-static struct command_result *json_peer_test2(struct command *cmd,
 					       const char *buffer,
 					       const jsmntok_t *obj UNNEEDED,
 					       const jsmntok_t *params)
@@ -2966,7 +2838,6 @@ static struct command_result *json_peer_test2(struct command *cmd,
 		}
 	}
 
-	printf("-----------\n");
 	printf("peer_exists_count: %d\n", peer_exists);
 	printf("-----------\n");
 
@@ -2998,13 +2869,13 @@ static struct command_result *json_peer_test2(struct command *cmd,
 	return command_success(cmd, response);
 }
 
-static const struct json_command peer_test2 = {
-	"peer-test2",
+static const struct json_command peer_channel_state = {
+	"peer-channel-state",
 	"developer",
-	json_peer_test2,
+	json_peer_channel_state,
 	"Find the state of the channel with the peer {id}"
 };
-AUTODATA(json_command, &peer_test2);
+AUTODATA(json_command, &peer_channel_state);
 
 // static void json_check_if_peer_exits(struct command *cmd, const char *buffer,
 // 				    const jsmntok_t *params)
@@ -3066,4 +2937,3 @@ AUTODATA(json_command, &peer_test2);
 // 	json_check_if_peer_exits,
 // 	"Finds if there exists the peer with {id}"
 // };
-// AUTODATA(json_command, &check_if_peer_exits);


### PR DESCRIPTION
Replaces body of old `peer-channel-state` with that of the rewritten `peer-test2`